### PR TITLE
Pull request template and minor repository tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = unset
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[openapi.json]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: git://github.com/Bahjat/pre-commit-golang
+    rev: master
+    hooks:
+    -   id: go-fmt-import
+    -   id: go-vet
+    -   id: go-lint
+    -   id: go-unit-tests
+    -   id: go-err-check
+

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+- Refactor (refactoring code, removing useless files)
+- Unit tests (no changes in the code)
+- Documentation update
+
+## Testing steps
+
+Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.


### PR DESCRIPTION
Adding
* Pull request template
* .editorconfig
* .pre-commit-config.yaml: only works if [pre-commit](https://pre-commit.com) is installed and ready. The used hooks require Go, but I don't think that would be a problem