### PR TITLE
Group config parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ license:
 	GO111MODULE=off go get -u github.com/google/addlicense && \
 		addlicense -c "Red Hat, Inc" -l "apache" -v ./
 
-before_commit: style test integration_tests license
+before_commit: style test license
 	./check_coverage.sh
 
 help: ## Show this help screen

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ api_spec_file = "openapi.json"
 * `api_prefix` is the prefix for the REST API path
 * `api_spec_file` is the location of a required OpenAPI specification file
 
+## Groups configuration
+
+The groups are defined in a YAML configuration file. You can find an example in
+[groups_config.yaml](groups_config.yaml).
+
+In order to define which groups configuration file is loaded by the service, you
+should use the `[groups]` section in the configuration file:
+
+```toml
+[groups]
+path = "groups_config.yaml"
+```
+
+Where `path` is the absolute or relative path to the groups configuration file.
+
 ## Local setup
 
 TBD

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 
+	"github.com/RedHatInsights/insights-content-service/groups"
 	"github.com/RedHatInsights/insights-content-service/server"
 )
 
@@ -37,6 +38,7 @@ const (
 // Config has exactly the same structure as *.toml file
 var Config struct {
 	Server server.Configuration `mapstructure:"server" toml:"server"`
+	Groups groups.Configuration `mapstructure:"groups" toml:"groups"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in configFileEnvVariableName or from env
@@ -96,6 +98,16 @@ func GetServerConfiguration() server.Configuration {
 	}
 
 	return Config.Server
+}
+
+// GetGroupsConfiguration returns groups configuration
+func GetGroupsConfiguration() groups.Configuration {
+	err := checkIfFileExists(Config.Groups.ConfigPath)
+	if err != nil {
+		log.Fatal().Err(err).Msg("The groups configuration file is not defined")
+	}
+
+	return Config.Groups
 }
 
 // checkIfFileExists returns nil if path doesn't exist or isn't a file, otherwise it returns corresponding error

--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,6 @@
 address = ":8080"
 api_prefix = "/api/v1/"
 api_spec_file = "openapi.json"
+
+[groups]
+path = "groups_config.yaml"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/RedHatInsights/insights-operator-utils v0.0.0-20200430065955-b0b675035360
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/droptheplot/abcgo v0.0.0-20171120220436-23529565504c // indirect
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf // indirect
 	github.com/kisielk/errcheck v1.2.0 // indirect
 	github.com/rs/zerolog v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/groups/configuration.go
+++ b/groups/configuration.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groups
+
+// Configuration represents configuration for groups configuration file
+type Configuration struct {
+	ConfigPath string `mapstructure:"path" toml:"path"`
+}

--- a/groups/groups.go
+++ b/groups/groups.go
@@ -18,6 +18,7 @@ package groups
 
 import (
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/go-yaml/yaml"
 )
@@ -29,9 +30,9 @@ type Group struct {
 	Tags        []string `yaml:"tags"`
 }
 
-// ParseGroupConfigFile
+// ParseGroupConfigFile parses the groups configuration file and return the read groups
 func ParseGroupConfigFile(groupConfigPath string) (map[string]Group, error) {
-	configBytes, err := ioutil.ReadFile(groupConfigPath)
+	configBytes, err := ioutil.ReadFile(filepath.Clean(groupConfigPath))
 	if err != nil {
 		return nil, err
 	}

--- a/groups/groups.go
+++ b/groups/groups.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groups
+
+import (
+	"io/ioutil"
+
+	"github.com/go-yaml/yaml"
+)
+
+// Group represent the relative information about a group
+type Group struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags"`
+}
+
+// ParseGroupConfigFile
+func ParseGroupConfigFile(groupConfigPath string) (map[string]Group, error) {
+	configBytes, err := ioutil.ReadFile(groupConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var groups map[string]Group
+
+	err = yaml.Unmarshal(configBytes, &groups)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return groups, nil
+}

--- a/groups_config.yaml
+++ b/groups_config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 service_availability:
   name: Service Availability
   description: Operator degraded, missing functionality due to misconfiguration or resource constraints.

--- a/groups_config.yaml
+++ b/groups_config.yaml
@@ -1,0 +1,20 @@
+service_availability:
+  name: Service Availability
+  description: Operator degraded, missing functionality due to misconfiguration or resource constraints.
+  tags:
+    - service_availability
+security:
+  name: Security
+  description: Issues related to certificates, user management, security groups, specific port usage, storage permissions, usage of kubeadmin account, exposed keys etc. 
+  tags:
+    - security
+fault_tolerance:
+  name: Fault Tolerance
+  description: Load balancer issues, machine api and autoscaler issues, failover issues, nodes down, cluster api/cluster provider issues.
+  tags:
+    - fault_tolerance
+performance:
+  name: Performance
+  description: High utilization, proposed tuned profiles, storage issues
+  tags:
+    - performance

--- a/server.go
+++ b/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-content-service/conf"
+	"github.com/RedHatInsights/insights-content-service/groups"
 )
 
 const (
@@ -51,6 +52,14 @@ var (
 
 // startService starts service and returns error code
 func startService() int {
+	groupsConfigPath := conf.GetGroupsConfiguration().ConfigPath
+	groups, _ := groups.ParseGroupConfigFile(groupsConfigPath)
+
+	for key, value := range groups {
+		fmt.Println("Group id ", key)
+		fmt.Println("Group content: ", value)
+	}
+
 	return ExitStatusOK
 }
 


### PR DESCRIPTION
# Description
This commit adds the first functionality for the service, allowing it to load a YAML configuration file with the groups definitions in an structured way

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
