### PR TITLE
Fix #30. Writer not used

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -15,8 +15,6 @@
 package server
 
 import (
-	"net/http"
-
 	"github.com/rs/zerolog/log"
 )
 
@@ -33,6 +31,6 @@ func (e *AuthenticationError) Error() string {
 }
 
 // handleServerError handles separate server errors and sends appropriate responses
-func handleServerError(writer http.ResponseWriter, err error) {
+func handleServerError(err error) {
 	log.Error().Err(err).Msg("handleServerError()")
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -39,7 +39,7 @@ func (server *HTTPServer) serveAPISpecFile(writer http.ResponseWriter, request *
 	if err != nil {
 		const message = "Error creating absolute path of OpenAPI spec file"
 		log.Error().Err(err).Msg(message)
-		handleServerError(writer, err)
+		handleServerError(err)
 		return
 	}
 


### PR DESCRIPTION
# Description

Removing `writer` argument from `handleError` because it is not used at all

Fixes #30 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Regular CI