### PR TITLE
Fixed issue #52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ default: build
 
 clean: ## Run go clean
 	@go clean
+	rm -f rest-api-tests
 
 build: ## Run go build
 	./build.sh


### PR DESCRIPTION
# Description

Executable used to run REST API tests is not cleared by using `make clean`

Fixes #52 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
