### PR TITLE
Fix checker bug that reports all tags as unknown

### DIFF
--- a/checker/main.go
+++ b/checker/main.go
@@ -156,7 +156,7 @@ func checkErrorCodeTags(groupCfg groupConfigMap, ruleName string, errCode string
 		for _, group := range groupCfg {
 			for _, tag := range group.Tags {
 				if tag == errTag {
-					errGroups[errTag] = append(tagGroups, group.Name)
+					tagGroups = append(tagGroups, group.Name)
 					break
 				}
 			}


### PR DESCRIPTION
# Description

I forgot to change the output of an `append` call, which broke the "unkown tag" check. 

This is a simple fix of that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

`make before_commit`
