### PR TITLE
Remove initialize argument

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -49,7 +49,7 @@ func New(config Configuration, groups map[string]groups.Group) *HTTPServer {
 func (server *HTTPServer) Start() error {
 	address := server.Config.Address
 	log.Info().Msgf("Starting HTTP server at '%s'", address)
-	router := server.Initialize(address)
+	router := server.Initialize()
 	server.Serv = &http.Server{Addr: address, Handler: router}
 	var err error
 
@@ -72,8 +72,8 @@ func (server *HTTPServer) Stop(ctx context.Context) error {
 }
 
 // Initialize perform the server initialization
-func (server *HTTPServer) Initialize(address string) http.Handler {
-	log.Info().Msgf("Initializing HTTP server at '%s'", address)
+func (server *HTTPServer) Initialize() http.Handler {
+	log.Info().Msgf("Initializing HTTP server at '%s'", server.Config.Address)
 
 	router := mux.NewRouter().StrictSlash(true)
 

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -131,7 +131,7 @@ func makeRequest(t testing.TB, request *APIRequest, url string) *http.Request {
 
 // ExecuteRequest executes http request on a testServer
 func ExecuteRequest(testServer *server.HTTPServer, req *http.Request, config *server.Configuration) *httptest.ResponseRecorder {
-	router := testServer.Initialize(config.Address)
+	router := testServer.Initialize()
 
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)


### PR DESCRIPTION
# Description

Minor fix to remove an unneeded parameter from `server.Initialize`

Fixes #65 

## Type of change
- Refactor (refactoring code, removing useless files)

## Testing steps
Regular CI