### PR TITLE
Endpoint serving all content encoded with gob

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ clean: ## Run go clean
 build: ## Run go build
 	./build.sh
 
+checker/checker: checker/main.go
+	cd checker
+	go build
+	cd ..
+
 fmt: ## Run go fmt -w for all sources
 	@echo "Running go formatting"
 	./gofmt.sh

--- a/README.md
+++ b/README.md
@@ -94,9 +94,19 @@ path = "groups_config.yaml"
 
 Where `path` is the absolute or relative path to the groups configuration file.
 
-## Local setup
+## Static content configuration
 
-TBD
+This service parses the rules static content at startup. For that reason, configuring the directory
+where the rules content is deployed is mandatory within the configuration.
+
+To define the path where the service will look up for rules content, you should define the following:
+
+```toml
+[content]
+path = "rules-content"
+```
+
+Where `path` can be the absolute or relative path to the rules content directory.
 
 ## REST API schema based on OpenAPI 3.0
 

--- a/checker/main.go
+++ b/checker/main.go
@@ -175,10 +175,10 @@ func checkErrorCodeTags(groupCfg groupConfigMap, ruleName string, errCode string
 
 // Base rule content checks.
 
-func checkRuleFileNotEmpty(ruleName, fileName string, value []byte) {
+func checkRuleFileNotEmpty(ruleName, fileName string, value string) {
 	checkStringNotEmpty(
 		fmt.Sprintf("content file '%s' of rule '%s'", fileName, ruleName),
-		string(value),
+		value,
 	)
 }
 
@@ -191,7 +191,7 @@ func checkRuleAttributeNotEmpty(ruleName, attribName, value string) {
 
 // Error code content checks.
 
-func checkErrorCodeFileNotEmpty(ruleName, errorCode, fileName string, value []byte) {
+func checkErrorCodeFileNotEmpty(ruleName, errorCode, fileName string, value string) {
 	checkStringNotEmpty(
 		fmt.Sprintf("content file '%s' of error code '%s|%s'", fileName, ruleName, errorCode),
 		string(value),

--- a/checker/main.go
+++ b/checker/main.go
@@ -194,7 +194,7 @@ func checkRuleAttributeNotEmpty(ruleName, attribName, value string) {
 func checkErrorCodeFileNotEmpty(ruleName, errorCode, fileName string, value string) {
 	checkStringNotEmpty(
 		fmt.Sprintf("content file '%s' of error code '%s|%s'", fileName, ruleName, errorCode),
-		string(value),
+		value,
 	)
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -90,6 +90,33 @@
           }
         }
       }
+    },
+    "/content": {
+      "get": {
+        "summary": "Returns static content for all rules.",
+        "operationId": "getContent",
+        "responses": {
+          "200": {
+            "description": "A encoding/gob encoded value with all the static content.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rule-content": {
+                      "type": "strings"
+                    },
+                    "status": {
+                      "type": "strings",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -66,9 +66,12 @@ func (server HTTPServer) getStaticContent(writer http.ResponseWriter, request *h
 	var err error
 	buffer := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buffer)
-	err = encoder.Encode(server.Content)
-	encodedContent := buffer.Bytes()
+	if err = encoder.Encode(server.Content); err != nil {
+		log.Error().Err(err).Msg("Cannot encode rules static content")
+		handleServerError(err)
+	}
 
+	encodedContent := buffer.Bytes()
 	err = responses.SendOK(writer, responses.BuildOkResponseWithData("rule-content", encodedContent))
 
 	if err != nil {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"bytes"
+	"encoding/gob"
 	"net/http"
 	"path/filepath"
 
@@ -61,15 +63,16 @@ func (server *HTTPServer) listOfGroups(writer http.ResponseWriter, request *http
 
 // getStaticContent returns all the parsed rules' content
 func (server HTTPServer) getStaticContent(writer http.ResponseWriter, request *http.Request) {
-	data := map[string]interface{}{
-		"config": server.Content.Config,
-		"rules":  server.Content.Rules,
-	}
-	err := responses.SendOK(writer, responses.BuildOkResponseWithData("response", data))
+	var err error
+	buffer := new(bytes.Buffer)
+	encoder := gob.NewEncoder(buffer)
+	err = encoder.Encode(server.Content)
+	encodedContent := buffer.Bytes()
+
+	err = responses.SendOK(writer, responses.BuildOkResponseWithData("rule-content", encodedContent))
 
 	if err != nil {
 		log.Error().Err(err)
 		handleServerError(err)
 	}
-
 }


### PR DESCRIPTION
# Description
This PR includes a modification over the current `content` endpoint, making it use `encoding/gob` encoder to produce a binary data to be sent over the network.

In addition, some changes into the static content data structures in order to reflect the current type of some of the fields (`string` instead `[]byte`), making it easier to consume by the Smart Proxy.

Fixes #45 

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)

## Testing steps
Regular CI