### PR TITLE
Minor helper fix in order to use operator-utils helpers

### DIFF
--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedHatInsights/insights-content-service/content"
@@ -112,7 +113,7 @@ func AssertAPIRequest(
 	}
 	if expectedResponse.BodyChecker != nil {
 		bodyBytes, err := ioutil.ReadAll(response.Body)
-		FailOnError(t, err)
+		helpers.FailOnError(t, err)
 
 		expectedResponse.BodyChecker(t, expectedResponse.Body, string(bodyBytes))
 	} else if len(expectedResponse.Body) != 0 {
@@ -122,7 +123,7 @@ func AssertAPIRequest(
 
 func makeRequest(t testing.TB, request *APIRequest, url string) *http.Request {
 	req, err := http.NewRequest(request.Method, url, strings.NewReader(request.Body))
-	FailOnError(t, err)
+	helpers.FailOnError(t, err)
 
 	if len(request.AuthorizationToken) != 0 {
 		req.Header.Set("Authorization", request.AuthorizationToken)
@@ -146,9 +147,9 @@ func ExecuteRequest(testServer *server.HTTPServer, req *http.Request, config *se
 // also validates both expected and body to be a valid json
 func CheckResponseBodyJSON(t testing.TB, expectedJSON string, body io.ReadCloser) {
 	result, err := ioutil.ReadAll(body)
-	FailOnError(t, err)
+	helpers.FailOnError(t, err)
 
-	AssertStringsAreEqualJSON(t, expectedJSON, string(result))
+	helpers.AssertStringsAreEqualJSON(t, expectedJSON, string(result))
 }
 
 // checkResponseHeaders checks if headers are the same as in expected


### PR DESCRIPTION
# Description

Due to changes on insights-operator-utils and its tests/helpers package, some changes are needed in the services

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Regular CI