### PR TITLE
We should download only tested 'latest-release' of rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN umask 0022 && \
     mkdir -p $RULES_CONTENT_DIR && \
     echo "echo $GITHUB_API_TOKEN" > $GIT_ASKPASS && \
     chmod +x $GIT_ASKPASS && \
-    git -C $RULES_CONTENT_DIR clone $RULES_REPO $RULES_CONTENT_DIR && \
+    git -C $RULES_CONTENT_DIR clone --depth=1 --branch latest-release $RULES_REPO $RULES_CONTENT_DIR && \
     make build && \
     chmod a+x insights-content-service
 


### PR DESCRIPTION
# Description

Currently, we build the container with the rules from master branch. We should download only tested `latest-release` ref.

Fixes # (issue)

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally with:
```
buildah bud --build-arg GITHUB_API_TOKEN=token -f Dockerfile -t ics .
```