### PR TITLE
Improve docgo generation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,13 @@ docs/packages/%.html: %.go
 	docgo -outdir $(dir $@) $^
 	addlicense -c "Red Hat, Inc" -l "apache" -v $@
 
+godoc: export GO111MODULE=off
 godoc: install_docgo install_addlicense ${DOCFILES}
 
+install_docgo: export GO111MODULE=off
 install_docgo:
 	[[ `command -v docgo` ]] || GO111MODULE=off go get -u github.com/dhconnelly/docgo
 
+install_docgo: export GO111MODULE=off
 install_addlicense:
 	[[ `command -v addlicense` ]] || GO111MODULE=off go get -u github.com/google/addlicense


### PR DESCRIPTION
# Description

Avoid `docgo` to update `go.sum` and `go.mod`

Fixes #121 

## Type of change

- Refactor (refactoring code, removing useless files)
- Documentation update

## Testing steps

Regular CI