### PR TITLE
Fixed issue #114

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -94,6 +94,7 @@
     "/content": {
       "get": {
         "summary": "Returns static content for all rules.",
+        "description": "The static content is taken from the memory cache and send in gob format",
         "operationId": "getContent",
         "responses": {
           "200": {


### PR DESCRIPTION
# Description

No description found for endpoint `/content` and method `get`

Fixes #114

## Type of change

- Documentation update

## Testing steps

N/A