### PR TITLE
Fixed issue #113

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -50,6 +50,7 @@
     "/groups": {
       "get": {
         "summary": "Returns a list of groups.",
+        "description": "List of all groups represented as an array of objects is returned in a response",
         "operationId": "getGroups",
         "responses": {
           "200": {


### PR DESCRIPTION
# Description

No description found for endpoint `/groups` and method `get`

Fixes #113

## Type of change

- Documentation update

## Testing steps

N/A