### PR TITLE
Adding encoded content to the instance to provent re-generating it

### DIFF
--- a/docs/packages/server/endpoints.html
+++ b/docs/packages/server/endpoints.html
@@ -139,6 +139,7 @@ limitations under the License.
 	<div class="literal">&#34;net/http&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;path/filepath&#34;</div><div class="operator"></div>
 
+	<div class="ident">httputils</div> <div class="literal">&#34;github.com/RedHatInsights/insights-operator-utils/http&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/gorilla/mux&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/prometheus/client_golang/prometheus/promhttp&#34;</div><div class="operator"></div>
 <div class="operator">)</div><div class="operator"></div>
@@ -202,7 +203,10 @@ limitations under the License.
       <tr class="section">
 	<td class="doc"><p>OpenAPI specs</p>
 </td>
-	<td class="code"><pre><code>	<div class="ident">router</div><div class="operator">.</div><div class="ident">HandleFunc</div><div class="operator">(</div><div class="ident">openAPIURL</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">serveAPISpecFile</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Methods</div><div class="operator">(</div><div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">)</div><div class="operator"></div>
+	<td class="code"><pre><code>	<div class="ident">router</div><div class="operator">.</div><div class="ident">HandleFunc</div><div class="operator">(</div>
+		<div class="ident">openAPIURL</div><div class="operator">,</div>
+		<div class="ident">httputils</div><div class="operator">.</div><div class="ident">CreateOpenAPIHandler</div><div class="operator">(</div><div class="ident">server</div><div class="operator">.</div><div class="ident">Config</div><div class="operator">.</div><div class="ident">APISpecFile</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">Config</div><div class="operator">.</div><div class="ident">Debug</div><div class="operator">,</div> <div class="ident">true</div><div class="operator">)</div><div class="operator">,</div>
+	<div class="operator">)</div><div class="operator">.</div><div class="ident">Methods</div><div class="operator">(</div><div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>

--- a/docs/packages/server/handlers.html
+++ b/docs/packages/server/handlers.html
@@ -139,7 +139,6 @@ limitations under the License.
 	<div class="literal">&#34;bytes&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;encoding/gob&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;net/http&#34;</div><div class="operator"></div>
-	<div class="literal">&#34;path/filepath&#34;</div><div class="operator"></div>
 
 	<div class="literal">&#34;github.com/RedHatInsights/insights-operator-utils/responses&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/rs/zerolog/log&#34;</div><div class="operator"></div>
@@ -160,24 +159,6 @@ limitations under the License.
 		<div class="ident">handleServerError</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 		<div class="keyword">return</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
-<div class="operator">}</div><div class="operator"></div>
-
-</code></pre></td>
-      </tr>
-      
-      <tr class="section">
-	<td class="doc"><p>serveAPISpecFile serves an OpenAPI specifications file specified in config file</p>
-</td>
-	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">server</div> <div class="operator">*</div><div class="ident">HTTPServer</div><div class="operator">)</div> <div class="ident">serveAPISpecFile</div><div class="operator">(</div><div class="ident">writer</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">ResponseWriter</div><div class="operator">,</div> <div class="ident">request</div> <div class="operator">*</div><div class="ident">http</div><div class="operator">.</div><div class="ident">Request</div><div class="operator">)</div> <div class="operator">{</div>
-	<div class="ident">absPath</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">filepath</div><div class="operator">.</div><div class="ident">Abs</div><div class="operator">(</div><div class="ident">server</div><div class="operator">.</div><div class="ident">Config</div><div class="operator">.</div><div class="ident">APISpecFile</div><div class="operator">)</div><div class="operator"></div>
-	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-		<div class="keyword">const</div> <div class="ident">message</div> <div class="operator">=</div> <div class="literal">&#34;Error creating absolute path of OpenAPI spec file&#34;</div><div class="operator"></div>
-		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="ident">message</div><div class="operator">)</div><div class="operator"></div>
-		<div class="ident">handleServerError</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
-		<div class="keyword">return</div><div class="operator"></div>
-	<div class="operator">}</div><div class="operator"></div>
-
-	<div class="ident">http</div><div class="operator">.</div><div class="ident">ServeFile</div><div class="operator">(</div><div class="ident">writer</div><div class="operator">,</div> <div class="ident">request</div><div class="operator">,</div> <div class="ident">absPath</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>
@@ -207,19 +188,21 @@ limitations under the License.
       <tr class="section">
 	<td class="doc"><p>getStaticContent returns all the parsed rules' content</p>
 </td>
-	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">server</div> <div class="ident">HTTPServer</div><div class="operator">)</div> <div class="ident">getStaticContent</div><div class="operator">(</div><div class="ident">writer</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">ResponseWriter</div><div class="operator">,</div> <div class="ident">request</div> <div class="operator">*</div><div class="ident">http</div><div class="operator">.</div><div class="ident">Request</div><div class="operator">)</div> <div class="operator">{</div>
-	<div class="ident">buffer</div> <div class="operator">:=</div> <div class="ident">new</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">.</div><div class="ident">Buffer</div><div class="operator">)</div><div class="operator"></div>
-	<div class="ident">encoder</div> <div class="operator">:=</div> <div class="ident">gob</div><div class="operator">.</div><div class="ident">NewEncoder</div><div class="operator">(</div><div class="ident">buffer</div><div class="operator">)</div><div class="operator"></div>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">server</div> <div class="operator">*</div><div class="ident">HTTPServer</div><div class="operator">)</div> <div class="ident">getStaticContent</div><div class="operator">(</div><div class="ident">writer</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">ResponseWriter</div><div class="operator">,</div> <div class="ident">request</div> <div class="operator">*</div><div class="ident">http</div><div class="operator">.</div><div class="ident">Request</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">if</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">encodedContent</div> <div class="operator">==</div> <div class="ident">nil</div> <div class="operator">{</div>
+		<div class="ident">buffer</div> <div class="operator">:=</div> <div class="ident">new</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">.</div><div class="ident">Buffer</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">encoder</div> <div class="operator">:=</div> <div class="ident">gob</div><div class="operator">.</div><div class="ident">NewEncoder</div><div class="operator">(</div><div class="ident">buffer</div><div class="operator">)</div><div class="operator"></div>
 
-	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">encoder</div><div class="operator">.</div><div class="ident">Encode</div><div class="operator">(</div><div class="ident">server</div><div class="operator">.</div><div class="ident">Content</div><div class="operator">)</div><div class="operator">;</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Cannot encode rules static content&#34;</div><div class="operator">)</div><div class="operator"></div>
-		<div class="ident">handleServerError</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
-		<div class="keyword">return</div><div class="operator"></div>
+		<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">encoder</div><div class="operator">.</div><div class="ident">Encode</div><div class="operator">(</div><div class="ident">server</div><div class="operator">.</div><div class="ident">Content</div><div class="operator">)</div><div class="operator">;</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+			<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Cannot encode rules static content&#34;</div><div class="operator">)</div><div class="operator"></div>
+			<div class="ident">handleServerError</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
+			<div class="keyword">return</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">server</div><div class="operator">.</div><div class="ident">encodedContent</div> <div class="operator">=</div> <div class="ident">buffer</div><div class="operator">.</div><div class="ident">Bytes</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
-	<div class="ident">encodedContent</div> <div class="operator">:=</div> <div class="ident">buffer</div><div class="operator">.</div><div class="ident">Bytes</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
-
-	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">responses</div><div class="operator">.</div><div class="ident">Send</div><div class="operator">(</div><div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div> <div class="ident">writer</div><div class="operator">,</div> <div class="ident">encodedContent</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">responses</div><div class="operator">.</div><div class="ident">Send</div><div class="operator">(</div><div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div> <div class="ident">writer</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">encodedContent</div><div class="operator">)</div><div class="operator"></div>
 	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
 		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 		<div class="ident">handleServerError</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator"></div>

--- a/docs/packages/server/server.html
+++ b/docs/packages/server/server.html
@@ -166,6 +166,8 @@ REST API endpoints are available:</p>
 	<div class="ident">Groups</div>  <div class="keyword">map</div><div class="operator">[</div><div class="ident">string</div><div class="operator">]</div><div class="ident">groups</div><div class="operator">.</div><div class="ident">Group</div><div class="operator"></div>
 	<div class="ident">Content</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">RuleContentDirectory</div><div class="operator"></div>
 	<div class="ident">Serv</div>    <div class="operator">*</div><div class="ident">http</div><div class="operator">.</div><div class="ident">Server</div><div class="operator"></div>
+
+	<div class="ident">encodedContent</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">byte</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>

--- a/docs/packages/server/server_test.html
+++ b/docs/packages/server/server_test.html
@@ -335,7 +335,7 @@ limitations under the License.
 		<div class="ident">Method</div><div class="operator">:</div>   <div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">,</div>
 		<div class="ident">Endpoint</div><div class="operator">:</div> <div class="ident">config</div><div class="operator">.</div><div class="ident">APISpecFile</div><div class="operator">,</div>
 	<div class="operator">}</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIResponse</div><div class="operator">{</div>
-		<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+		<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">StatusInternalServerError</div><div class="operator">,</div>
 	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -54,19 +54,21 @@ func (server *HTTPServer) listOfGroups(writer http.ResponseWriter, request *http
 }
 
 // getStaticContent returns all the parsed rules' content
-func (server HTTPServer) getStaticContent(writer http.ResponseWriter, request *http.Request) {
-	buffer := new(bytes.Buffer)
-	encoder := gob.NewEncoder(buffer)
+func (server *HTTPServer) getStaticContent(writer http.ResponseWriter, request *http.Request) {
+	if server.encodedContent == nil {
+		buffer := new(bytes.Buffer)
+		encoder := gob.NewEncoder(buffer)
 
-	if err := encoder.Encode(server.Content); err != nil {
-		log.Error().Err(err).Msg("Cannot encode rules static content")
-		handleServerError(err)
-		return
+		if err := encoder.Encode(server.Content); err != nil {
+			log.Error().Err(err).Msg("Cannot encode rules static content")
+			handleServerError(err)
+			return
+		}
+
+		server.encodedContent = buffer.Bytes()
 	}
 
-	encodedContent := buffer.Bytes()
-
-	err := responses.Send(http.StatusOK, writer, encodedContent)
+	err := responses.Send(http.StatusOK, writer, server.encodedContent)
 	if err != nil {
 		log.Error().Err(err)
 		handleServerError(err)

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,8 @@ type HTTPServer struct {
 	Groups  map[string]groups.Group
 	Content content.RuleContentDirectory
 	Serv    *http.Server
+
+	encodedContent []byte
 }
 
 // New constructs new implementation of Server interface


### PR DESCRIPTION
# Description

This commit keeps the encoded static content in memory, in order to prevent that it is encoded for each HTTP request. This is a lazy-initialization approach: the encoded content will be generated when it is first needed

Fixes #133 

## Type of change


- Refactor (refactoring code, removing useless files)

## Testing steps

Regular CI