### PR TITLE
Fix #210. Add metrics endpoint to openapi.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo style run test cover license before_commit help godoc install_docgo install_addlicense
+.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo style run test cover license openapi-check before_commit help godoc install_docgo install_addlicense
 
 SOURCES:=$(shell find . -name '*.go')
 BINARY:=insights-content-service
@@ -59,6 +59,9 @@ abcgo: ## Run ABC metrics checker
 	@echo "Run ABC metrics checker"
 	./abcgo.sh
 
+openapi-check:
+	./check_openapi.sh
+
 style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
 
 run: clean build ## Build the project and executes the binary
@@ -77,7 +80,7 @@ integration_tests: ## Run all integration tests
 license: install_addlicense
 	addlicense -c "Red Hat, Inc" -l "apache" -v ./
 
-before_commit: style test license
+before_commit: style test openapi-check license
 	./check_coverage.sh
 
 help: ## Show this help screen

--- a/check_openapi.sh
+++ b/check_openapi.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Testing OpenAPI specifications file"
+# shellcheck disable=2181
+
+if docker run --rm -v "${PWD}":/local/:Z openapitools/openapi-generator-cli validate -i ./local/openapi.json; then
+    echo "OpenAPI spec file is OK"
+else
+    echo "OpenAPI spec file validation failed"
+    exit 1
+fi

--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
     "description": "Insights Content Service",
     "version": "1.0.0"
   },
-  "paths": {
+  "paths": { 
     "/openapi.json": {
       "get": {
         "summary": "Returns the OpenAPI specification JSON.",
@@ -117,6 +117,21 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Read all metrics exposed by this service",
+        "description": "Set of metrics provided by insights-operator-utils library providing total number of requests counter, API endpoints response times, and counter of HTTP status code responses. Additionally it is possible to consume all metrics provided by Go runtime. These metrics start with go_ and process_ prefixes.",
+        "operationId": "getMetrics",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {}
+            },
+            "description": "Default response containing all metrics in semi-structured text format"
           }
         }
       }


### PR DESCRIPTION
# Description

Adds `/metrics` endpoint to OpenAPI specification for this service.

Fixes #210 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Regular CI