### PR TITLE
Fix error keys metadata retrieval when parsing rules content

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -79,11 +79,11 @@ func readFilesIntoFileContent(baseDir string, filelist []string) (map[string][]b
 
 // transformMetadataCondition takes content of condition field in metadata.yaml
 // and transforms it into a simple string
-func transformMetadataCondition(parsedCondition *interface{}, errorContent *RuleErrorKeyContent) error {
+func transformMetadataCondition(parsedMetadata *ParsedErrorKeyMetadata, errorContent *RuleErrorKeyContent) error {
+	parsedCondition := &parsedMetadata.Condition
 	switch (*parsedCondition).(type) {
 	case string:
 		errorContent.Metadata.Condition = (*parsedCondition).(string)
-		return nil
 	case []interface{}:
 		parsedSlice := (*parsedCondition).([]interface{})
 		conditions := make([]string, len(parsedSlice))
@@ -95,10 +95,17 @@ func transformMetadataCondition(parsedCondition *interface{}, errorContent *Rule
 			conditions[index] = condition
 		}
 		errorContent.Metadata.Condition = strings.Join(conditions, "; ")
-		return nil
 	default:
 		return &InvalidItem{FileName: "metadata.yaml", KeyName: "condition"}
 	}
+
+	errorContent.Metadata.Description = parsedMetadata.Description
+	errorContent.Metadata.Impact = parsedMetadata.Impact
+	errorContent.Metadata.Likelihood = parsedMetadata.Likelihood
+	errorContent.Metadata.PublishDate = parsedMetadata.PublishDate
+	errorContent.Metadata.Status = parsedMetadata.Status
+	errorContent.Metadata.Tags = parsedMetadata.Tags
+	return nil
 }
 
 // createErrorContents takes a mapping of files into contents and perform
@@ -130,7 +137,7 @@ func createErrorContents(contentRead map[string][]byte) (*RuleErrorKeyContent, e
 	}
 
 	if parsedMetadata.Condition != nil {
-		err := transformMetadataCondition(&parsedMetadata.Condition, &errorContent)
+		err := transformMetadataCondition(&parsedMetadata, &errorContent)
 		return &errorContent, err
 	}
 	return &errorContent, nil

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -44,8 +44,11 @@ func TestContentParseOK(t *testing.T) {
 	rule1Content, exists := con.Rules["rule1"]
 	assert.True(t, exists, "'rule1' content is missing")
 
-	_, exists = rule1Content.ErrorKeys["err_key"]
+	errKey, exists := rule1Content.ErrorKeys["err_key"]
 	assert.True(t, exists, "'err_key' error content is missing")
+
+	condition := errKey.Metadata.Condition
+	assert.Equal(t, "a simple condition", condition, "'rule1' condition does not have expected content")
 }
 
 // TestContentParseOKNoContent checks that parsing content when there is no rule

--- a/tests/content/ok/external/rules/rule1/err_key/metadata.yaml
+++ b/tests/content/ok/external/rules/rule1/err_key/metadata.yaml
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-condition: "a simple condiiton"
+condition: "a simple condition"
 status: "inactive"
 publish_date: "2020-04-03T16:13:30+02:00"


### PR DESCRIPTION
# Description

Fix parsing issue detected in molodec and integration tests

Fixes #183 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Updated UTs
