### PR TITLE
Resolution more info optional

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Build and deploy Jekyll site to GitHub Pages
 
 on:

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -exv
 

--- a/checker/main.go
+++ b/checker/main.go
@@ -114,9 +114,7 @@ func checkRuleContent(groupCfg groupConfigMap) {
 		checkRuleAttributeNotEmpty(ruleName, "product_code", ruleContent.Plugin.ProductCode)
 		checkRuleAttributeNotEmpty(ruleName, "python_module", ruleContent.Plugin.PythonModule)
 
-		checkRuleFileNotEmpty(ruleName, "more_info.md", string(ruleContent.MoreInfo))
 		checkRuleFileNotEmpty(ruleName, "reason.md", ruleContent.Reason)
-		checkRuleFileNotEmpty(ruleName, "resolution.md", ruleContent.Resolution)
 		checkRuleFileNotEmpty(ruleName, "summary.md", ruleContent.Summary)
 
 		if len(ruleContent.ErrorKeys) == 0 {

--- a/content/content.go
+++ b/content/content.go
@@ -19,13 +19,14 @@ package content
 
 import (
 	"fmt"
-	"github.com/RedHatInsights/insights-operator-utils/types"
-	"github.com/go-yaml/yaml"
-	"github.com/rs/zerolog/log"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/RedHatInsights/insights-operator-utils/types"
+	"github.com/go-yaml/yaml"
+	"github.com/rs/zerolog/log"
 )
 
 // Logging messages
@@ -158,16 +159,16 @@ func createRuleContent(contentRead map[string][]byte, errorKeys map[string]RuleE
 	}
 
 	if contentRead["resolution.md"] == nil {
-		return nil, &MissingMandatoryFile{FileName: "resolution.md"}
+		ruleContent.Resolution = ""
+	} else {
+		ruleContent.Resolution = string(contentRead["resolution.md"])
 	}
-
-	ruleContent.Resolution = string(contentRead["resolution.md"])
 
 	if contentRead["more_info.md"] == nil {
-		return nil, &MissingMandatoryFile{FileName: "more_info.md"}
+		ruleContent.MoreInfo = ""
+	} else {
+		ruleContent.MoreInfo = string(contentRead["more_info.md"])
 	}
-
-	ruleContent.MoreInfo = string(contentRead["more_info.md"])
 
 	if contentRead["plugin.yaml"] == nil {
 		return nil, &MissingMandatoryFile{FileName: "plugin.yaml"}

--- a/content/content.go
+++ b/content/content.go
@@ -143,6 +143,14 @@ func parseErrorContents(ruleDirPath string) (map[string]RuleErrorKeyContent, err
 func createRuleContent(contentRead map[string][]byte, errorKeys map[string]RuleErrorKeyContent) (*RuleContent, error) {
 	ruleContent := RuleContent{ErrorKeys: errorKeys}
 
+	if contentRead["plugin.yaml"] == nil {
+		return nil, &MissingMandatoryFile{FileName: "plugin.yaml"}
+	}
+
+	if err := yaml.Unmarshal(contentRead["plugin.yaml"], &ruleContent.Plugin); err != nil {
+		return nil, err
+	}
+
 	if contentRead["summary.md"] == nil {
 		return nil, &MissingMandatoryFile{FileName: "summary.md"}
 	}
@@ -150,9 +158,9 @@ func createRuleContent(contentRead map[string][]byte, errorKeys map[string]RuleE
 	ruleContent.Summary = string(contentRead["summary.md"])
 
 	if contentRead["reason.md"] == nil {
-		// check error keys for a reason
 		ruleContent.Reason = ""
 		ruleContent.HasReason = false
+		log.Warn().Msgf("reason for rule [%s] is empty", ruleContent.Plugin.PythonModule)
 	} else {
 		ruleContent.Reason = string(contentRead["reason.md"])
 		ruleContent.HasReason = true
@@ -160,22 +168,16 @@ func createRuleContent(contentRead map[string][]byte, errorKeys map[string]RuleE
 
 	if contentRead["resolution.md"] == nil {
 		ruleContent.Resolution = ""
+		log.Warn().Msgf("resolution for rule [%s] is empty", ruleContent.Plugin.PythonModule)
 	} else {
 		ruleContent.Resolution = string(contentRead["resolution.md"])
 	}
 
 	if contentRead["more_info.md"] == nil {
 		ruleContent.MoreInfo = ""
+		log.Warn().Msgf("more_info for rule [%s] is empty", ruleContent.Plugin.PythonModule)
 	} else {
 		ruleContent.MoreInfo = string(contentRead["more_info.md"])
-	}
-
-	if contentRead["plugin.yaml"] == nil {
-		return nil, &MissingMandatoryFile{FileName: "plugin.yaml"}
-	}
-
-	if err := yaml.Unmarshal(contentRead["plugin.yaml"], &ruleContent.Plugin); err != nil {
-		return nil, err
 	}
 
 	return &ruleContent, nil

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -79,11 +79,12 @@ func TestContentParseInvalidDir2(t *testing.T) {
 	assert.EqualError(t, err, fmt.Sprintf("open %s/config.yaml: not a directory", notADirPath))
 }
 
-// TestContentParseMissingFile checks how missing file(s) in content directory are handled
+// TestContentParseMissingFile checks how missing mandatory file(s) in content directory are handled
 func TestContentParseMissingFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	log.Logger = zerolog.New(buf)
 
+	// has mandatory summary.md missing
 	_, err := content.ParseRuleContentDir("../tests/content/missing/")
 
 	assert.Nil(t, err)

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: v1
 kind: Template

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # --------------------------------------------
 # Options that must be configured by app owner

--- a/tests/content/missing/external/rules/rule2/summary.md
+++ b/tests/content/missing/external/rules/rule2/summary.md
@@ -1,1 +1,0 @@
-# Rule 2 Summary

--- a/tests/content/missing/internal/rules/rule3/summary.md
+++ b/tests/content/missing/internal/rules/rule3/summary.md
@@ -1,1 +1,0 @@
-# Rule 2 Summary

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Updates the ./rules-content directory with the latest rules to test with
+
+function clean_up() {
+    rm -rf "$CLONE_TEMP_DIR"
+}
+trap clean_up EXIT
+
+RULES_REPO="https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp.git"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+CONTENT_DIR="${SCRIPT_DIR}/rules-content"
+TUTORIAL_RULE_CONTENT_DIR="${SCRIPT_DIR}/rules/tutorial/content"
+
+CLONE_TEMP_DIR="${SCRIPT_DIR}/.tmp"
+RULES_CONTENT="${CLONE_TEMP_DIR}/content/"
+
+echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
+
+if ! git clone --depth=1 --branch master "${RULES_REPO}" "${CLONE_TEMP_DIR}"
+then
+    echo "Couldn't clone rules repository"
+    exit 1
+fi
+
+if ! rm -rf "${CONTENT_DIR}"
+then
+    echo "Couldn't remove previous content"
+    exit 1
+fi
+
+if ! mv "${RULES_CONTENT}" "${CONTENT_DIR}"
+then
+    echo "Couldn't move rules content from cloned repository"
+    exit 1
+fi
+
+rm -rf "${CLONE_TEMP_DIR}"
+
+cp -a "${TUTORIAL_RULE_CONTENT_DIR}/." "${CONTENT_DIR}/external/rules/"
+
+echo "${CONTENT_DIR} updated with latest rules"
+exit 0


### PR DESCRIPTION
# Description
External rules used to have a requirement that the resolution steps must be filled in. For this reason, the `resolution.md` and `more_info.md` files were mandatory even if the resolution was unknown at the time. It was often worked around by providing these .md files empty.

This MR makes the presence of those files entirely optional, which increases the number of parsed rules from 48 to 55.

Because the attributes could've been empty before because of the empty .md files and according to Georgii and https://docs.google.com/document/d/1KxaZqxE0-Q2r3Y8KoVFBmbxfTHHQQA0Tu9jPMmI1P9E/edit?usp=sharing it won't break any UI element if `resolution` and `more_info` are `""`

Fixes CCXDEV-5058

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Ran locally with the latest version of rule content (which has 1 broken external rule without resolution.md) and all external rules were parsed correctly. Ran smart-proxy, retrieved all content and checked the response

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
