### PR TITLE
temporarily disable haberdasher because of duplicated/overwritten logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,13 @@ COPY --from=rules /content /rules-content
 # copy tutorial/fake rule to external rules to be hit by all reports
 COPY rules/tutorial/content/ /rules-content/external/rules
 
-RUN curl -L -o /usr/bin/haberdasher \
-https://github.com/RedHatInsights/haberdasher/releases/download/v0.1.3/haberdasher_linux_amd64 && \
-chmod 755 /usr/bin/haberdasher
+# temporarily disabled haberdasher because it was duplicating logs (TODO try again later)
+# RUN curl -L -o /usr/bin/haberdasher \
+# https://github.com/RedHatInsights/haberdasher/releases/download/v0.1.3/haberdasher_linux_amd64 && \
+# chmod 755 /usr/bin/haberdasher
 
 USER 1001
 
-ENTRYPOINT ["/usr/bin/haberdasher"]
+# ENTRYPOINT ["/usr/bin/haberdasher"]
 
 CMD ["/insights-content-service"]


### PR DESCRIPTION
# Description
After setting everything up, Jose Luis tried running the Docker image locally and found out that haberdasher is causing duplicated and overwritten logs when ran as a Docker image (Thanks Jose). This DOES NOT happen when insights-content-service is ran locally and it only happens at the start of the service where the most important logs (rule content parsing) were overwritten by another message.

Temporarily disabling haberdasher to allow me to check the logs to help me with fixes for https://issues.redhat.com/browse/OCPBUGSM-31640 

Created a JIRA task to not forget to enable it later https://issues.redhat.com/browse/CCXDEV-5389

## Type of change

Please delete options that are not relevant.

- Bug fix (???)

## Testing steps
I hope CI will tell me that :grin: 

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
