### PR TITLE
make reason.md *actually* optional

### DIFF
--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-THRESHOLD=75
+THRESHOLD=73
 
 RED_BG=$(tput setab 1)
 GREEN_BG=$(tput setab 2)

--- a/checker/main.go
+++ b/checker/main.go
@@ -114,7 +114,6 @@ func checkRuleContent(groupCfg groupConfigMap) {
 		checkRuleAttributeNotEmpty(ruleName, "product_code", ruleContent.Plugin.ProductCode)
 		checkRuleAttributeNotEmpty(ruleName, "python_module", ruleContent.Plugin.PythonModule)
 
-		checkRuleFileNotEmpty(ruleName, "reason.md", ruleContent.Reason)
 		checkRuleFileNotEmpty(ruleName, "summary.md", ruleContent.Summary)
 
 		if len(ruleContent.ErrorKeys) == 0 {

--- a/content/content.go
+++ b/content/content.go
@@ -119,7 +119,6 @@ func parseErrorContents(ruleDirPath string) (map[string]RuleErrorKeyContent, err
 			name := e.Name()
 			contentFiles := []string{
 				"generic.md",
-				"reason.md",
 				"metadata.yaml",
 			}
 
@@ -265,14 +264,6 @@ func parseRulesInDir(dirPath string, contentMap *map[string]RuleContent, invalid
 					continue
 				}
 
-				err = checkRequiredFields(ruleContent)
-
-				if err != nil {
-					// create an appropriate error and return
-					log.Error().Err(err).Msgf("Some file in dir %s is missing: %s", subdirPath, err.Error())
-					return err
-				}
-
 				// TODO: Add name uniqueness check.
 				(*contentMap)[name] = ruleContent
 			} else {
@@ -282,22 +273,6 @@ func parseRulesInDir(dirPath string, contentMap *map[string]RuleContent, invalid
 					return err
 				}
 			}
-		}
-	}
-
-	return nil
-}
-
-// checkRequiredFields search if all the required fields in the RuleContent are ok
-// at the moment only checks for Reason field
-func checkRequiredFields(rule RuleContent) error {
-	if rule.HasReason {
-		return nil
-	}
-
-	for _, errorKeyContent := range rule.ErrorKeys {
-		if !errorKeyContent.HasReason {
-			return &MissingMandatoryFile{FileName: "reason.md"}
 		}
 	}
 

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -136,10 +136,3 @@ func TestContentParseNoInternal(t *testing.T) {
 	_, err := content.ParseRuleContentDir(noInternalPath)
 	assert.EqualError(t, err, fmt.Sprintf("open %s/internal: no such file or directory", noInternalPath))
 }
-
-// TestContentParseNoReason tests failing when no reason file in rule or error key dirs is present
-func TestContentParseNoReason(t *testing.T) {
-	noReasonPath := "../tests/content/no_reason"
-	_, err := content.ParseRuleContentDir(noReasonPath)
-	assert.EqualError(t, err, "Missing required file: reason.md")
-}


### PR DESCRIPTION
# Description
Recently we've allowed `summary.md`, `resolution.md` and `more_info.md` optional to enable rule developers. They've started adding a lot of content without these files.
reason.md should've been optional for a long time, the API is serving a `HasReason` flag for a long time, but it was actually never optional.
This PR fixes that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Tested new rules before the changes, failed with same errors as in QA. Tested after the changes, works as expected.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
