### PR TITLE
New `Info` endpoint

### DIFF
--- a/content-service.go
+++ b/content-service.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Red Hat, Inc.
+Copyright © 2020, 2021 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -105,6 +105,9 @@ func startService() ExitCode {
 	serverInstance = server.New(serverCfg, parsedGroups, contentDir,
 		ruleContentStatusMap)
 
+	// fill-in additional info used by /info endpoint handler
+	fillInInfoParams(serverInstance.InfoParams)
+
 	err = serverInstance.Start()
 	if err != nil {
 		log.Error().Err(err).Msg("HTTP(s) start error")
@@ -112,6 +115,16 @@ func startService() ExitCode {
 	}
 
 	return ExitStatusOK
+}
+
+// fillInInfoParams function fills-in additional info used by /info endpoint
+// handler
+func fillInInfoParams(params map[string]string) {
+	params["BuildVersion"] = BuildVersion
+	params["BuildTime"] = BuildTime
+	params["BuildBranch"] = BuildBranch
+	params["BuildCommit"] = BuildCommit
+	params["UtilsVersion"] = UtilsVersion
 }
 
 func printInfo(msg string, val string) {

--- a/content-service_test.go
+++ b/content-service_test.go
@@ -186,3 +186,25 @@ func TestPrintRules(t *testing.T) {
 	retval := int(main.PrintRules())
 	assert.Equal(t, main.ExitStatusReadContentError, retval)
 }
+
+// TestFillInInfoParams test the behaviour of function fillInInfoParams
+func TestFillInInfoParams(t *testing.T) {
+	// map to be used by this unit test
+	m := make(map[string]string)
+
+	// preliminary test if Go Universe is still ok
+	assert.Empty(t, m, "Map should be empty at the beginning")
+
+	// try to fill-in all info params
+	main.FillInInfoParams(m)
+
+	// preliminary test if Go Universe is still ok
+	assert.Len(t, m, 5, "Map should contains exactly five items")
+
+	// does the map contain all expected keys?
+	assert.Contains(t, m, "BuildVersion")
+	assert.Contains(t, m, "BuildTime")
+	assert.Contains(t, m, "BuildBranch")
+	assert.Contains(t, m, "BuildCommit")
+	assert.Contains(t, m, "UtilsVersion")
+}

--- a/export_test.go
+++ b/export_test.go
@@ -37,4 +37,5 @@ var (
 	LogVersionInfo   = logVersionInfo
 	PrintGroups      = printGroups
 	PrintRules       = printRules
+	FillInInfoParams = fillInInfoParams
 )

--- a/openapi.json
+++ b/openapi.json
@@ -189,6 +189,37 @@
         }
       }
     },
+    "/info": {
+      "get": {
+        "summary": "Returns basic information about content service.",
+        "description": "InfoEndpoint returns basic information about content service version, utils repository version, commit hash etc.",
+        "operationId": "InfoEndpoint",
+        "responses": {
+          "200": {
+            "description": "A map containing information about content service.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "info": {
+                      "type": "object",
+                      "additionalProperties": {
+                         "type": "string"
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/metrics": {
       "get": {
         "summary": "Read all metrics exposed by this service",

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -37,6 +37,9 @@ const (
 	// StatusEndpoint returns status of all rules that have been read and
 	// parsed
 	StatusEndpoint = "status"
+	// InfoEndpoint returns basic information about content service
+	// version, utils repository version, commit hash etc.
+	InfoEndpoint = "info"
 )
 
 func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
@@ -48,6 +51,7 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(apiPrefix+GroupsEndpoint, server.listOfGroups).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc(apiPrefix+AllContentEndpoint, server.getStaticContent).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc(apiPrefix+StatusEndpoint, server.ruleContentStates).Methods(http.MethodGet, http.MethodOptions)
+	router.HandleFunc(apiPrefix+InfoEndpoint, server.infoMap).Methods(http.MethodGet, http.MethodOptions)
 
 	// Prometheus metrics
 	router.Handle(apiPrefix+MetricsEndpoint, promhttp.Handler()).Methods(http.MethodGet)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -56,6 +56,23 @@ func (server *HTTPServer) listOfGroups(writer http.ResponseWriter, request *http
 	}
 }
 
+// infoMap returns map of additional information about this service
+func (server *HTTPServer) infoMap(writer http.ResponseWriter, request *http.Request) {
+	if server.InfoParams == nil {
+		err := errors.New("InfoParams is empty")
+		log.Error().Err(err)
+		handleServerError(err)
+		return
+	}
+
+	err := responses.SendOK(writer, responses.BuildOkResponseWithData("info", server.InfoParams))
+	if err != nil {
+		log.Error().Err(err)
+		handleServerError(err)
+		return
+	}
+}
+
 // ruleContentStates returns status of all rules that have been read and parsed
 func (server *HTTPServer) ruleContentStates(writer http.ResponseWriter, request *http.Request) {
 	query := request.URL.Query()

--- a/server/server.go
+++ b/server/server.go
@@ -35,10 +35,11 @@ import (
 
 // HTTPServer in an implementation of Server interface
 type HTTPServer struct {
-	Config  Configuration
-	Groups  map[string]groups.Group
-	Content content.RuleContentDirectory
-	Serv    *http.Server
+	Config     Configuration
+	InfoParams map[string]string
+	Groups     map[string]groups.Group
+	Content    content.RuleContentDirectory
+	Serv       *http.Server
 
 	encodedContent       []byte
 	groupsList           []groups.Group
@@ -54,6 +55,7 @@ func New(config Configuration, groups map[string]groups.Group,
 		Groups:               groups,
 		Content:              contentDir,
 		ruleContentStatusMap: ruleContentStatusMap,
+		InfoParams:           make(map[string]string),
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -170,6 +170,16 @@ func TestServeAPIWrongEndpoint(t *testing.T) {
 	})
 }
 
+// TestServeInfoMap checks the REST API server behaviour for info endpoint
+func TestServeInfoMap(t *testing.T) {
+	helpers.AssertAPIRequest(t, &config, &helpers.APIRequest{
+		Method:   http.MethodGet,
+		Endpoint: "info",
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+	})
+}
+
 // TestServeListOfGroups checks the REST API server behaviour for group listing endpoint
 func TestServeListOfGroups(t *testing.T) {
 	helpers.AssertAPIRequest(t, &config, &helpers.APIRequest{


### PR DESCRIPTION
# Description

New `Info` endpoint that returns basic information about Content Service - version, commit hash, `utils` version etc.

Fixes #316

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

```
$ curl localhost:8080/api/v1/info | jq .

{
  "info": {
    "BuildBranch": "info-endpoint",
    "BuildCommit": "a985007e982f6c82152e14c5436154525d176735",
    "BuildTime": "Fri 29 Oct 2021 04:27:26 PM CEST",
    "BuildVersion": "0.5",
    "UtilsVersion": "v1.21.2"
  },
  "status": "ok"
}
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
