### PR TITLE
[CCXDEV-6472] Update go image version to 1.16

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.1'
+          go-version: '^1.16.1'
       - name: Generate docgo
         run: make godoc
       - name: Generate Jekyll site

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM quay.io/cloudservices/ccx-rules-ocp:2021.11.16 AS rules
 
-FROM registry.redhat.io/rhel8/go-toolset:1.14 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.16 AS builder
 
 COPY . .
 

--- a/go.sum
+++ b/go.sum
@@ -36,9 +36,6 @@ github.com/RedHatInsights/insights-operator-utils v1.6.2/go.mod h1:RW9Jq4LgqIkV3
 github.com/RedHatInsights/insights-operator-utils v1.6.7/go.mod h1:ott1/rkxcyQtK6XdYj1Ur3XGSYRAHTplJiV5RKkij2o=
 github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBzlQdIihhGnwTpdw+bD8i8Fdh/OE9rdo=
 github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
-github.com/RedHatInsights/insights-operator-utils v1.19.2 h1:tJ6DHdNJMUorQf4R1hd0eZVS/wADYI/HixsSVA2kCxM=
-github.com/RedHatInsights/insights-operator-utils v1.19.2/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
-github.com/RedHatInsights/insights-operator-utils v1.21.0 h1:P688UpKrbLJ5pbLj0j3qRanROPl/eKv4ieFm7UyUSB4=
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2 h1:xE2VyoOr+7LWAT59D234/n4PW6PlkV1wAOrJPDtCOoE=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
@@ -46,10 +43,9 @@ github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
-github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023 h1:Ot6Rk8utrv02RMVTrGU/+QLSp+m5341pvq8auwlbDls=
 github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023/go.mod h1:SDeBuNY8AIwkD4JB5/I54ArWG7qngP5/Ydn7xbu2iZo=
-github.com/RedHatInsights/insights-results-aggregator-data v1.1.2 h1:r522n6apxrTa1hKthDO9RnST2OyjE3JTlWG3LDZnBh8=
 github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbiccYJ8whbpLLvNGMiaFzyMPs1A/2/Jh0P2U9DXF+4=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.1 h1:7jPQzozA6bGcD93Ar7BVrBfPg7vpjJ8D6hTDMHAiYO8=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=


### PR DESCRIPTION
# Description

Use [RHEL image](https://catalog.redhat.com/software/containers/rhel8/go-toolset/5b9c810add19c70b45cbd666?container-tabs=overview) with `go 1.16` version.

Fixes [CCXDEV-6472](https://issues.redhat.com/browse/CCXDEV-6472).

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
