### PR TITLE
Fixed deprecated `ioutil` calls

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -240,7 +240,7 @@ func createErrorContents(contentRead map[string][]byte) (*RuleErrorKeyContent, e
 // This implicitly checks that the directory exists,
 // so it is not necessary to ever check that elsewhere.
 func parseErrorContents(ruleDirPath string) (map[string]RuleErrorKeyContent, error) {
-	entries, err := ioutil.ReadDir(ruleDirPath)
+	entries, err := os.ReadDir(ruleDirPath)
 	if err != nil {
 		return nil, err
 	}

--- a/content/content.go
+++ b/content/content.go
@@ -20,7 +20,6 @@ package content
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"

--- a/content/content.go
+++ b/content/content.go
@@ -107,7 +107,7 @@ func readFilesIntoFileContent(baseDir string, filelist []string) (map[string][]b
 	for _, name := range filelist {
 		log.Info().Msgf("Parsing %s/%s", baseDir, name)
 		var err error
-		rawBytes, err := ioutil.ReadFile(filepath.Clean(path.Join(baseDir, name)))
+		rawBytes, err := os.ReadFile(filepath.Clean(path.Join(baseDir, name)))
 		if err != nil {
 			filesContent[name] = nil
 			log.Error().Err(err)

--- a/content/content.go
+++ b/content/content.go
@@ -344,7 +344,7 @@ func parseRuleContent(ruleDirPath string) (RuleContent, error) {
 // parseGlobalContentConfig reads the configuration file used to store
 // metadata used by all rule content, such as impact dictionary.
 func parseGlobalContentConfig(configPath string) (GlobalRuleConfig, error) {
-	configBytes, err := ioutil.ReadFile(filepath.Clean(configPath))
+	configBytes, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
 		return GlobalRuleConfig{}, err
 	}

--- a/content/content.go
+++ b/content/content.go
@@ -394,7 +394,7 @@ func parseRulesInDir(dirPath string, ruleType ctypes.RuleType,
 	contentMap *map[string]RuleContent, invalidRules *[]string,
 	ruleContentStatusMap map[string]ctypes.RuleContentStatus) error {
 	// read the whole content of specified directory
-	entries, err := ioutil.ReadDir(dirPath)
+	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return err
 	}

--- a/groups/groups.go
+++ b/groups/groups.go
@@ -17,6 +17,7 @@ limitations under the License.
 package groups
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/go-yaml/yaml"

--- a/groups/groups.go
+++ b/groups/groups.go
@@ -17,7 +17,6 @@ limitations under the License.
 package groups
 
 import (
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/go-yaml/yaml"
@@ -33,7 +32,7 @@ type Group struct {
 
 // ParseGroupConfigFile parses the groups configuration file and return the read groups
 func ParseGroupConfigFile(groupConfigPath string) (map[string]Group, error) {
-	configBytes, err := ioutil.ReadFile(filepath.Clean(groupConfigPath))
+	configBytes, err := os.ReadFile(filepath.Clean(groupConfigPath))
 	if err != nil {
 		log.Error().Err(err).Msg("Error reading groups configuration file")
 		return nil, err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -112,7 +112,7 @@ func TestServerStartError(t *testing.T) {
 
 // TestServeAPISpecFileOK checks whether it is possible to access openapi.json via REST API server
 func TestServeAPISpecFileOK(t *testing.T) {
-	fileData, err := ioutil.ReadFile(config.APISpecFile)
+	fileData, err := os.ReadFile(config.APISpecFile)
 	helpers.FailOnError(t, err)
 
 	helpers.AssertAPIRequest(t, &config, &helpers.APIRequest{


### PR DESCRIPTION
# Description

Fixed deprecated `ioutil` calls

Fixes #361
Fixes #362
Fixes #363
Fixes #364
Fixes #365
Fixes #366

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
