### PR TITLE
[CCXDEV-6834] Show the ocp rules version in /info

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,5 +22,7 @@ commit=$(git rev-parse HEAD)
 
 utils_version=$(go list -m github.com/RedHatInsights/insights-operator-utils | awk '{print $2}')
 
-go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version'"
+ocp_rules_version=$(grep "^FROM quay.io\/cloudservices\/.* AS rules$" Dockerfile | awk -F'FROM quay.io/cloudservices/|AS rules' '{print $2}')
+
+go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version' -X 'main.OCPRulesVersion=$ocp_rules_version'"
 exit $?

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ commit=$(git rev-parse HEAD)
 
 utils_version=$(go list -m github.com/RedHatInsights/insights-operator-utils | awk '{print $2}')
 
-ocp_rules_version=$(grep "^FROM quay.io\/cloudservices\/.* AS rules$" Dockerfile | awk -F'FROM quay.io/cloudservices/|AS rules' '{print $2}')
+ocp_rules_version=$(grep "^FROM quay.io\/cloudservices\/.* AS rules$" Dockerfile | awk -F'FROM quay.io/cloudservices/| AS rules' '{print $2}')
 
 go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version' -X 'main.OCPRulesVersion=$ocp_rules_version'"
 exit $?

--- a/content-service.go
+++ b/content-service.go
@@ -72,6 +72,10 @@ var (
 	// UtilsVersion contains currently used version of
 	// github.com/RedHatInsights/insights-operator-utils package
 	UtilsVersion = "*not set*"
+
+	// OCPRulesVersion contains currently used version of
+	// https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp package
+	OCPRulesVersion = "*not set*"
 )
 
 // startService starts service and returns error code
@@ -125,6 +129,7 @@ func fillInInfoParams(params map[string]string) {
 	params["BuildBranch"] = BuildBranch
 	params["BuildCommit"] = BuildCommit
 	params["UtilsVersion"] = UtilsVersion
+	params["OCPRulesVersion"] = OCPRulesVersion
 }
 
 func printInfo(msg, val string) {
@@ -137,6 +142,7 @@ func printVersionInfo() ExitCode {
 	printInfo("Branch:", BuildBranch)
 	printInfo("Commit:", BuildCommit)
 	printInfo("Utils version:", UtilsVersion)
+	printInfo("OCP rules version:", OCPRulesVersion)
 	return ExitStatusOK
 }
 
@@ -207,6 +213,7 @@ func logVersionInfo() {
 	initInfoLog("Branch: " + BuildBranch)
 	initInfoLog("Commit: " + BuildCommit)
 	initInfoLog("Utils version:" + UtilsVersion)
+	initInfoLog("OCP rules version:" + OCPRulesVersion)
 }
 
 const helpMessageTemplate = `

--- a/content-service_test.go
+++ b/content-service_test.go
@@ -199,7 +199,7 @@ func TestFillInInfoParams(t *testing.T) {
 	main.FillInInfoParams(m)
 
 	// preliminary test if Go Universe is still ok
-	assert.Len(t, m, 5, "Map should contains exactly five items")
+	assert.Len(t, m, 6, "Map should contains exactly six items")
 
 	// does the map contain all expected keys?
 	assert.Contains(t, m, "BuildVersion")
@@ -207,4 +207,5 @@ func TestFillInInfoParams(t *testing.T) {
 	assert.Contains(t, m, "BuildBranch")
 	assert.Contains(t, m, "BuildCommit")
 	assert.Contains(t, m, "UtilsVersion")
+	assert.Contains(t, m, "OCPRulesVersion")
 }


### PR DESCRIPTION
# Description

Pass the OCP rules version as build params and return the value in the `/info` endpoint.

Fixes #CXDEV-6834

**IMPORTANT**: this change will modify a v1 endpoint at smart proxy!

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Content service:

```
❯ curl localhost:8080/api/v1/info | jq
{
  "info": {
    "BuildBranch": "master",
    "BuildCommit": "e3cc637c1db1b1e1c0649d83c266c9a58842f89a",
    "BuildTime": "Fri Jul  8 12:21:32 PM CEST 2022",
    "BuildVersion": "0.1",
    "OCPRulesVersion": "ccx-rules-ocp:2022.07.06",    <----------------
    "UtilsVersion": "v1.22.0"
  },
  "status": "ok"
}
```

Smart Proxy:

```
❯ curl localhost:8081/api/v1/info | jq
{
  "info": {
    "SmartProxy": {
      "BuildBranch": "CCXDEV-6834",
      "BuildCommit": "4205beb1dc0bf46285fa5e334431c2b4afcda4ac",
      "BuildTime": "Fri Jul  8 12:37:46 PM CEST 2022",
      "BuildVersion": "0.1",
      "UtilsVersion": "v1.23.3",
      "status": "ok"
    },
    "Aggregator": {
      "BuildBranch": "CCXDEV-6834",
      "BuildCommit": "51d62933c0866705b65e4f858a3be91dac8f85b4",
      "BuildTime": "Fri Jul  8 12:28:56 PM CEST 2022",
      "BuildVersion": "0.1",
      "OCPRulesVersion": "ccx-rules-ocp:2022.07.06 ",
      "UtilsVersion": "v1.22.0",
      "status": "ok"
    },
    "ContentService": {
      "BuildBranch": "CCXDEV-6834",
      "BuildCommit": "51d62933c0866705b65e4f858a3be91dac8f85b4",
      "BuildTime": "Fri Jul  8 12:28:56 PM CEST 2022",
      "BuildVersion": "0.1",
      "OCPRulesVersion": "ccx-rules-ocp:2022.07.06", <-----------------
      "UtilsVersion": "v1.22.0",
      "status": "ok"
    }
  },
  "status": "ok"
}
```

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
