### PR TITLE
[CCXDEV-8714] include ccx-rules-ocp directly, avoid rules image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/cloudservices/ccx-rules-ocp:2022.07.20 AS rules
-
-FROM registry.redhat.io/rhel8/go-toolset:1.16 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7 AS builder
 
 COPY . .
 
@@ -31,7 +29,7 @@ COPY --from=builder /opt/app-root/src/insights-content-service .
 COPY --from=builder /opt/app-root/src/openapi.json /openapi/openapi.json
 COPY --from=builder /opt/app-root/src/groups_config.yaml /groups/groups_config.yaml
 # copy just the rule content instead of the whole ocp-rules repository
-COPY --from=rules /content /rules-content
+COPY rules-content /rules-content
 # copy tutorial/fake rule to external rules to be hit by all reports
 COPY rules/tutorial/content/ /rules-content/external/rules
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 # this is improper - we need to start using tags in GitHub properly
-version=0.1
+
+set -exv
+
+version=0.2
 
 buildtime=$(date)
 branch=$(git rev-parse --abbrev-ref HEAD)
@@ -22,7 +25,10 @@ commit=$(git rev-parse HEAD)
 
 utils_version=$(go list -m github.com/RedHatInsights/insights-operator-utils | awk '{print $2}')
 
-ocp_rules_version=$(grep "^FROM quay.io\/cloudservices\/.* AS rules$" Dockerfile | awk -F'FROM quay.io/cloudservices/| AS rules' '{print $2}')
+ocp_rules_version=$(grep "^CCX_RULES_OCP_TAG=\".*\"$" update_rules_content.sh | awk -F'CCX_RULES_OCP_TAG="|"' '{print $2}')
+
+# Update ccx-rules-ocp
+./update_rules_content.sh
 
 go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version' -X 'main.OCPRulesVersion=$ocp_rules_version'"
 exit $?

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -18,9 +18,6 @@ set -exv
 IMAGE="quay.io/cloudservices/ccx-insights-content-service"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
-# Update ccx-rules-ocp
-./update_rules_content.sh
-
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
     exit 1

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -exv
 
 IMAGE="quay.io/cloudservices/ccx-insights-content-service"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+# Update ccx-rules-ocp
+./update_rules_content.sh
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -39,19 +39,19 @@ echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
 if ! git clone --depth=1 --branch "${CCX_RULES_OCP_TAG}" "${RULES_REPO}" "${CLONE_TEMP_DIR}"
 then
     echo "Couldn't clone rules repository"
-    exit 1
+    exit $?
 fi
 
 if ! rm -rf "${CONTENT_DIR}"
 then
     echo "Couldn't remove previous content"
-    exit 1
+    exit $?
 fi
 
 if ! mv "${RULES_CONTENT}" "${CONTENT_DIR}"
 then
     echo "Couldn't move rules content from cloned repository"
-    exit 1
+    exit $?
 fi
 
 rm -rf "${CLONE_TEMP_DIR}"

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -15,10 +15,15 @@
 
 # Updates the ./rules-content directory with the latest rules to test with
 
+set -exv
+
 function clean_up() {
     rm -rf "$CLONE_TEMP_DIR"
 }
 trap clean_up EXIT
+
+# Updated with every new ccx-rules-opc release.
+CCX_RULES_OCP_TAG="2022.07.20"
 
 RULES_REPO="https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp.git"
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -31,7 +36,7 @@ RULES_CONTENT="${CLONE_TEMP_DIR}/content/"
 
 echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
 
-if ! git clone --depth=1 --branch master "${RULES_REPO}" "${CLONE_TEMP_DIR}"
+if ! git clone --depth=1 --branch "${CCX_RULES_OCP_TAG}" "${RULES_REPO}" "${CLONE_TEMP_DIR}"
 then
     echo "Couldn't clone rules repository"
     exit 1


### PR DESCRIPTION
# Description

This removes the dependency on ccx-rules-ocp image for building image. Rules are now directly cloned and bundled with the image.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
