### PR TITLE
Update CODEOWNERS with file for OCP rules versio bump MRs.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 * @tisnik @Bee-lee @JoseLSegura @dpensi @lobziik @matysek @epapbak @JiriPapousek @juandspy
 
 # Version bump pull requests do not require approva - owned by everyone.
-Dockerfile
+update_rules_content.sh


### PR DESCRIPTION
# Description

The file to update OCP rules version was changed. Dockerfile -> update_rules_content.sh

However, to allow automerging of  OCP rules version bump pull requests the filename has to be updated in CODEOWNERS.

## Type of change

- Bug fix (non-breaking change which fixes an issue)