### PR TITLE
Build the service using only test rules in BDD tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       services:
         - docker
       before_script:
-        - ./build.sh
+        - ./build.sh --test-rules-only
         - cid=$(docker run -itd -e TESTS_TO_EXECUTE=insights-content-service-tests quay.io/ccxdev/insights-behavioral-spec:ci sh -c "sleep infinity")
         - docker cp $PWD $cid:`docker exec $cid bash -c 'echo "$HOME"'`
       script:

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Behaviour tests for this service are included in [Insights Behavioral
 Spec](https://github.com/RedHatInsights/insights-behavioral-spec) repository.
 In order to run these tests, the following steps need to be made:
 
+1. Build this service using `./build.sh --test-rules-only`
 1. clone the [Insights Behavioral Spec](https://github.com/RedHatInsights/insights-behavioral-spec) repository
-1. go into the cloned subdirectory `insights-behavioral-spec`
-1. run the `aggregator_tests.sh` from this subdirectory
+1. copy this directory with the `insights-content-service` executable into the `insights-behavioral-spec` subdirectory
+1. run the `insights_content_service_test.sh` from the `insights-behavioral-spec` subdirectory
 
 List of all test scenarios prepared for this service is available at
 <https://redhatinsights.github.io/insights-behavioral-spec/feature_list.html#insights-content-service>

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ utils_version=$(go list -m github.com/RedHatInsights/insights-operator-utils | a
 ocp_rules_version=$(grep "^CCX_RULES_OCP_TAG=\".*\"$" update_rules_content.sh | awk -F'CCX_RULES_OCP_TAG="|"' '{print $2}')
 
 # Update ccx-rules-ocp
-./update_rules_content.sh
+./update_rules_content.sh "$@"
 
 go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version' -X 'main.OCPRulesVersion=$ocp_rules_version'"
 exit $?

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -42,6 +42,8 @@ then
     then
         echo "Creating content dir with tutorial and test rules"
         mkdir -p "${CONTENT_DIR}/external/"
+        mkdir -p "${CONTENT_DIR}/internal/"
+        mkdir -p "${CONTENT_DIR}/ocs/"
         cp -R "${SCRIPT_DIR}/rules" "${CONTENT_DIR}/external/."
         cp "${TUTORIAL_RULE_CONTENT_DIR}/config.yaml" "${CONTENT_DIR}/."
         exit 0

--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -36,8 +36,19 @@ TEST_RULE_CONTENT_DIR="${SCRIPT_DIR}/rules/test/content"
 CLONE_TEMP_DIR="${SCRIPT_DIR}/.tmp"
 RULES_CONTENT="${CLONE_TEMP_DIR}/content/"
 
-echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
+if [ $# -ne 0 ]
+then
+    if [[ "$*" == *-test-rules-only* ]]
+    then
+        echo "Creating content dir with tutorial and test rules"
+        mkdir -p "${CONTENT_DIR}/external/"
+        cp -R "${SCRIPT_DIR}/rules" "${CONTENT_DIR}/external/."
+        cp "${TUTORIAL_RULE_CONTENT_DIR}/config.yaml" "${CONTENT_DIR}/."
+        exit 0
+   fi
+fi
 
+echo "Attempting to clone repository into ${CLONE_TEMP_DIR}"
 if ! git clone --depth=1 --branch "${CCX_RULES_OCP_TAG}" "${RULES_REPO}" "${CLONE_TEMP_DIR}"
 then
     echo "Couldn't clone rules repository"


### PR DESCRIPTION
# Description

In order to build the service, the rules are needed. But downloading the ccx-ocp-rules is not needed in a testing environment.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
