### PR TITLE
Add check in build_deploy.sh to tag with security-compliance when that branch is built

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -34,5 +34,11 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
-docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+
+if [[ $GIT_BRANCH == "security-compliance" ]]; then
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:security-compliance"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:security-compliance"
+else
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+fi


### PR DESCRIPTION
cc @tisnik :eyes: 

# Description

This change to the build_deploy.sh script is for the new security-compliance branch. It just adds a check if the current branch is security-compliance, and if it is it tags the image and pushes it up. 

This will only be called on merge to the branch from app-interface. I am going to create that job here shortly. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
