### PR TITLE
add new 2022-IT-Root-CA.pem certificate to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY . .
 USER 0
 
 # clone rules content repository and build the content service
-RUN curl -ksL https://password.corp.redhat.com/RH-IT-Root-CA.crt \
-         -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt && \
+RUN curl -ksL https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt && \
+    curl -ksL https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem && \
     update-ca-trust && \
     umask 0022 && \
     make build && \


### PR DESCRIPTION
# Description
Old certificate will be removed next year and some servers are already requiring the new 2022 certificate issued in August 2023

https://issues.redhat.com/browse/CCXDEV-11664

https://source.redhat.com/groups/public/identity-access-management/rhcs_red_hat_certificate_system_wiki/faqs_new_corporate_root_certificate_authority

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Configuration update

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
