### PR TITLE
README fix with the objective of fixing release pipeline ephemeral deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Sources are located in [docs](https://github.com/RedHatInsights/insights-content
 ```
 Usage:
 
-    ./content-service [command]
+    ./insights-content-service [command]
 
 The commands are:
 


### PR DESCRIPTION
# Description

README now mentions how to start the service properly.

But the real goal of this PR is to get our rule release pipeline to pass (see https://gitlab.cee.redhat.com/ccx/ccx-rules-releaser/-/blob/master/scripts/common.sh#L41). Right now, the pipeline is trying to run the tests with the latest commit with message "Bumped ccx-rules-ocp version xxx", which was a version that could not be started properly due to the issue fixed in #506.

Fixes rule release ephemeral tests deployment

## Type of change

- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
