### PR TITLE
Revert "Bumped ccx-rules-ocp version"

### DIFF
--- a/update_rules_content.sh
+++ b/update_rules_content.sh
@@ -25,7 +25,7 @@ function clean_up() {
 trap clean_up EXIT
 
 # Updated with every new ccx-rules-opc release.
-CCX_RULES_OCP_TAG="2023.11.22"
+CCX_RULES_OCP_TAG="2023.11.08"
 
 RULES_REPO="https://gitlab.cee.redhat.com/ccx/ccx-rules-ocp.git"
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
Reverts RedHatInsights/insights-content-service#544 because this has to be squashed for the rule release pipeline to pass