### PR TITLE
fix: exclude goconst from test files in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,7 @@ linters:
       - path: _test\.go
         linters:
           - gosec
+          - goconst
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
## What broke and why

golangci-lint v2.12.0 changed `goconst` behavior to also check test files, flagging intentionally repeated string literals in `types/types_test.go` (e.g. `test impact`, `Cluster Node Restart`).

## Why this fix

Test data strings are intentionally repeated across test cases — extracting them to constants adds no correctness benefit and makes tests harder to read. Excluding `goconst` from `_test.go` paths is the correct approach.

## Unblocks

Allows https://github.com/RedHatInsights/content-service/pull/826 to pass CI and merge.