### PR TITLE
Use Go 1.25 for BDD

### DIFF
--- a/.github/workflows/bdd.yaml
+++ b/.github/workflows/bdd.yaml
@@ -12,3 +12,4 @@ jobs:
     uses: RedHatInsights/processing-tools/.github/workflows/bdd.yaml@master
     with:
       service: content-service
+      go_version: "1.25"


### PR DESCRIPTION
# Description

Bump Go version used by BDD tests

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
